### PR TITLE
Remove Friday from availability and scheduling

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -8,7 +8,7 @@ const userSchema = new mongoose.Schema({
     role: { type: String, enum: ['user', 'admin'], default: 'user' },
     availability: [
         {
-            day: { type: String, enum: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], required: true },
+            day: { type: String, enum: ['Monday', 'Tuesday', 'Wednesday', 'Thursday'], required: true },
             slots: [{ type: String, required: true }] // Each slot will be a string like '10:00-10:30'
         }
     ],

--- a/backend/routes/scheduleRoutes.js
+++ b/backend/routes/scheduleRoutes.js
@@ -152,7 +152,7 @@ router.get('/availability-export', adminOnly, async (req, res) => {
             return `FF${r}${g}${b}`.toUpperCase();
         }
 
-        const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+        const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday'];
 
         for (const day of days) {
             // Create a new sheet for each day

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -26,7 +26,7 @@ router.post('/signup', async (req, res) => {
 
     try {
         const normalizedEmail = email.trim().toLowerCase();
-        
+
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         if (!emailRegex.test(normalizedEmail)) {
             return res.status(400).json({ error: 'Invalid email format.' });
@@ -163,7 +163,7 @@ router.post('/availability', auth, async (req, res) => {
             return res.status(400).json({ error: 'Availability data is required and must be an array.' });
         }
 
-        const validDays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+        const validDays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday'];
         const isValid = availability.every(item =>
             validDays.includes(item.day) &&
             Array.isArray(item.slots) &&
@@ -429,7 +429,7 @@ router.post('/admin/availability/:id', auth, adminOnly, async (req, res) => {
         return res.status(400).json({ error: 'Availability must be a non-empty array.' });
     }
 
-    const validDays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+    const validDays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday'];
     const isValid = availability.every(item =>
         validDays.includes(item.day) &&
         Array.isArray(item.slots) &&

--- a/backend/scripts/cleanupRemoveFriday.js
+++ b/backend/scripts/cleanupRemoveFriday.js
@@ -1,0 +1,28 @@
+// Purpose: strip any Friday availability so future saves won't fail once the enum excludes Friday.
+
+require('dotenv').config({ path: '../.env' });
+const mongoose = require('mongoose');
+const User = require('../models/User'); 
+
+(async () => {
+  try {
+    await mongoose.connect(process.env.MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true });
+
+    // Find all users that have any Friday availability
+    const cursor = User.find({ 'availability.day': 'Friday' }).cursor();
+
+    let updated = 0;
+    for (let user = await cursor.next(); user != null; user = await cursor.next()) {
+      // Filter out Friday from the availability array
+      user.availability = (user.availability || []).filter(d => d.day !== 'Friday');
+      await user.save(); // save after removing Friday
+      updated++;
+    }
+
+    console.log(`Cleanup complete. Users updated: ${updated}`);
+    await mongoose.connection.close();
+  } catch (err) {
+    console.error('Cleanup failed:', err);
+    process.exit(1);
+  }
+})();

--- a/backend/scripts/seedMentorsAndAdmins.js
+++ b/backend/scripts/seedMentorsAndAdmins.js
@@ -47,7 +47,7 @@ const majorOptions = [
     'Other'
 ];
 
-const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday'];
 const timeSlots = [
     '10:00-10:30', '10:30-11:00', '11:00-11:30', '11:30-12:00',
     '12:00-12:30', '12:30-13:00', '13:00-13:30', '13:30-14:00',

--- a/backend/utils/scheduleAlgorithm.js
+++ b/backend/utils/scheduleAlgorithm.js
@@ -17,7 +17,7 @@ async function generateSchedule() {
         
         // Initialize schedule structure
         const schedule = {};
-        const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+        const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday'];
         const timeSlots = [
             '10:00-10:30', '10:30-11:00', '11:00-11:30', '11:30-12:00',
             '12:00-12:30', '12:30-13:00', '13:00-13:30', '13:30-14:00',
@@ -126,7 +126,7 @@ async function generateScheduleToCSV() {
     
     // Create CSV content
     let csvContent = 'Time Slot';
-    const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+    const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday'];
     
     // Add header row with days
     daysOfWeek.forEach(day => {
@@ -195,7 +195,7 @@ async function generateScheduleToExcel() {
     // Set up headers
     worksheet.columns = [
         { header: 'Time Slot', key: 'timeSlot', width: 15 },
-        ...['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'].flatMap(day => [
+        ...['Monday', 'Tuesday', 'Wednesday', 'Thursday'].flatMap(day => [
             { header: `${day} (Mentors)`, key: `${day.toLowerCase()}_mentors`, width: 30 }
         ])
     ];
@@ -213,7 +213,7 @@ async function generateScheduleToExcel() {
     timeSlots.forEach((timeSlot) => {
         const rowData = { timeSlot };
 
-        ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'].forEach(day => {
+        ['Monday', 'Tuesday', 'Wednesday', 'Thursday'].forEach(day => {
             const mentors = result.schedule[day][timeSlot];
             if (mentors.length > 0) {
                 mentors.forEach((mentor) => {

--- a/frontend/user_board.html
+++ b/frontend/user_board.html
@@ -122,6 +122,10 @@
     <div class="bg-white shadow-md rounded-lg p-6" id="availabilitySection">
       <h2 class="text-xl font-semibold mb-4">Select Your Weekly Availability</h2>
       <p id="coopNote" class="text-sm text-gray-500 italic mb-4"></p>
+      <p class="text-xs text-gray-500 mb-2">
+        Friday availability is currently disabled for Fall 2025.<br>
+        Please select 3 consecutive time slots, three times per week (Monday to Thursday).
+      </p>
 
       <div class="overflow-x-auto">
         <table class="w-full text-sm text-center">
@@ -132,7 +136,6 @@
               <th class="border px-2 py-1 bg-gray-200">Tuesday</th>
               <th class="border px-2 py-1 bg-gray-200">Wednesday</th>
               <th class="border px-2 py-1 bg-gray-200">Thursday</th>
-              <th class="border px-2 py-1 bg-gray-200">Friday</th>
             </tr>
           </thead>
 
@@ -169,7 +172,7 @@
 
 
   <script>
-    const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+    const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday'];
     const startHour = 10;
     const endHour = 16;
     const container = document.getElementById('availabilityBody');


### PR DESCRIPTION
Friday has been removed as a valid day for user availability and all scheduling logic across the backend and frontend. A cleanup script was added to strip existing Friday availability from users. The user interface and seed scripts were updated to reflect this change, and a notice was added to the frontend explaining the update for Fall 2025.